### PR TITLE
Fix undefined method in migration

### DIFF
--- a/src/Migration/Migration1705000002UpdateFor67Compatibility.php
+++ b/src/Migration/Migration1705000002UpdateFor67Compatibility.php
@@ -15,7 +15,7 @@ class Migration1705000002UpdateFor67Compatibility extends MigrationStep
     public function update(Connection $connection): void
     {
         // Check if table exists
-        $tableExists = $connection->getSchemaManager()->tablesExist(['mh_product_embeddings']);
+        $tableExists = $connection->createSchemaManager()->tablesExist(['mh_product_embeddings']);
         
         if (!$tableExists) {
             // Table doesn't exist yet, skip this migration


### PR DESCRIPTION
Update `getSchemaManager()` to `createSchemaManager()` to fix Doctrine DBAL compatibility.

This resolves an `UndefinedMethodError` caused by the deprecated `getSchemaManager()` method in newer Doctrine DBAL versions.