### PR TITLE
Fix controller loading issue

### DIFF
--- a/src/Resources/config/routes.xml
+++ b/src/Resources/config/routes.xml
@@ -4,6 +4,6 @@
         xsi:schemaLocation="http://symfony.com/schema/routing
         https://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <import resource="../../Controller/VectorSearchController.php" type="annotation" />
-    <import resource="../../Controller/PublicVectorSearchController.php" type="annotation" />
+    <import resource="../../Controller/VectorSearchController.php" type="attribute" />
+    <import resource="../../Controller/PublicVectorSearchController.php" type="attribute" />
 </routes> 


### PR DESCRIPTION
Update route import type to 'attribute' in `routes.xml` to match PHP 8 Attributes used in controllers.

The error "Cannot load resource ... Make sure there is a loader supporting the "annotation" type" occurred because the `routes.xml` was configured to load routes via `type="annotation"`, but the controllers were using the newer PHP 8 `%23[Route(...)]` attributes. Changing the type to `attribute` resolves this mismatch, allowing the routes to be correctly loaded.